### PR TITLE
Simplify defining mutually dependent parsers

### DIFF
--- a/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
+++ b/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
@@ -1,8 +1,8 @@
 {
   "type": "minor",
-  "comment": "Add lazy parser to simplyfy creating mutually dependent parsers",
+  "comment": "Add lazy parser to simplify creating mutually dependent parsers",
   "packageName": "typescript-parsec",
-  "email": "jwin@de.ibm.com",
+  "email": "2ndjpeg@gmail.com",
   "commit": "2417eab0f9f612b6eb9b6c6f6191ff3121eb1d95",
   "date": "2020-10-04T03:30:50.488Z"
 }

--- a/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
+++ b/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add lazy parser to simplify creating mutually dependent parsers",
+  "comment": "- add lazy parser to simplify creating mutually dependent parsers\n- add factory for parser modules to allow keeping structure in mutually dependent parsers",
   "packageName": "typescript-parsec",
   "email": "2ndjpeg@gmail.com",
   "commit": "2417eab0f9f612b6eb9b6c6f6191ff3121eb1d95",

--- a/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
+++ b/change/typescript-parsec-2020-10-04-05-30-50-lazy-parser-definitions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add lazy parser to simplyfy creating mutually dependent parsers",
+  "packageName": "typescript-parsec",
+  "email": "jwin@de.ibm.com",
+  "commit": "2417eab0f9f612b6eb9b6c6f6191ff3121eb1d95",
+  "date": "2020-10-04T03:30:50.488Z"
+}

--- a/packages/ts-parsec/src/Parsers/LazyParser.ts
+++ b/packages/ts-parsec/src/Parsers/LazyParser.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import type { Token } from '../Lexer';
+import type { Parser, ParserOutput } from './ParserInterface';
+
+export function lazy<TKind, TResult>(thunk: () => Parser<TKind, TResult>): Parser<TKind, TResult> {
+    return {
+        parse(token: Token<TKind> | undefined): ParserOutput<TKind, TResult> {
+            return thunk().parse(token);
+        }
+    };
+}

--- a/packages/ts-parsec/src/Parsers/ParserModule.ts
+++ b/packages/ts-parsec/src/Parsers/ParserModule.ts
@@ -7,14 +7,6 @@
 import { lazy } from './LazyParser';
 import type { Parser } from './ParserInterface';
 
-export type ParserDefinition<TKind, TResult> = <
-    TParserModule extends Record<string, (m: any) => Parser<TKind, TResult>>
->(
-    m: {
-        [K in keyof TParserModule]: Parser<TKind, TResult>;
-    }
-) => Parser<TKind, TResult>;
-
 const defineReadOnly = <Target, Value>(
     target: Target,
     propName: string | number | symbol,

--- a/packages/ts-parsec/src/Parsers/ParserModule.ts
+++ b/packages/ts-parsec/src/Parsers/ParserModule.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable:no-null-keyword
+// tslint:disable:no-any
+
+import { lazy } from './LazyParser';
+import type { Parser } from './ParserInterface';
+
+export type ParserDefinition<TKind, TResult> = <
+    TParserModule extends Record<string, (m: any) => Parser<TKind, TResult>>
+>(
+    m: {
+        [K in keyof TParserModule]: Parser<TKind, TResult>;
+    }
+) => Parser<TKind, TResult>;
+
+const defineReadOnly = <Target, Value>(
+    target: Target,
+    propName: string | number | symbol,
+    value: Value
+): Target & { readonly [name in typeof propName]: Value } =>
+    <Target & { readonly [name in typeof propName]: Value }>Object.defineProperty(target, propName, {
+        configurable: true,
+        writable: false,
+        enumerable: true,
+        value
+    });
+
+export function makeParserModule<TKind, TResult>(
+    definitions: Record<
+        string,
+        (
+            m: {
+                [K in keyof typeof definitions]: Parser<TKind, TResult>;
+            }
+        ) => Parser<TKind, TResult>
+    >,
+    entry: (
+        m: {
+            [K in keyof typeof definitions]: Parser<TKind, TResult>;
+        }
+    ) => Parser<TKind, TResult>
+): Parser<TKind, TResult> {
+    let parserModule = <{ [K in keyof typeof definitions]: Parser<TKind, TResult> }>Object.create(null);
+    for (const [key, parserThunk] of Object.entries(definitions)) {
+        parserModule = defineReadOnly(
+            parserModule,
+            key,
+            lazy(() => parserThunk(parserModule))
+        );
+    }
+    return entry(parserModule);
+}

--- a/packages/ts-parsec/src/index.ts
+++ b/packages/ts-parsec/src/index.ts
@@ -12,3 +12,5 @@ export * from './Parsers/ApplyParser';
 export * from './Parsers/AmbiguousParser';
 export * from './Parsers/ErrorParser';
 export * from './Parsers/Rule';
+export * from './Parsers/LazyParser';
+export * from './Parsers/ParserModule';

--- a/packages/tspc-test/package.json
+++ b/packages/tspc-test/package.json
@@ -31,6 +31,7 @@
   },
   "jest": {
     "testRegex": "/lib/Test.*\\.js",
-    "verbose": true
+    "verbose": true,
+    "testEnvironment": "node"
   }
 }

--- a/packages/tspc-test/src/TestParserModule.ts
+++ b/packages/tspc-test/src/TestParserModule.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable:no-duplicate-imports
+// tslint:disable:trailing-comma
+// tslint:disable:function-name
+
+import * as assert from 'assert';
+import { Parser, Token } from 'typescript-parsec';
+import { buildLexer, expectEOF, expectSingleResult } from 'typescript-parsec';
+import { alt, apply, kmid, lrec_sc, makeParserModule, seq, str, tok } from 'typescript-parsec';
+
+enum TokenKind {
+    Number,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    LParen,
+    RParen,
+    Space
+}
+
+const lexer = buildLexer([
+    [true, /^\d+(\.\d+)?/g, TokenKind.Number],
+    [true, /^\+/g, TokenKind.Add],
+    [true, /^\-/g, TokenKind.Sub],
+    [true, /^\*/g, TokenKind.Mul],
+    [true, /^\//g, TokenKind.Div],
+    [true, /^\(/g, TokenKind.LParen],
+    [true, /^\)/g, TokenKind.RParen],
+    [false, /^\s+/g, TokenKind.Space]
+]);
+
+function applyNumber(value: Token<TokenKind.Number>): number {
+    return +value.text;
+}
+
+function applyUnary(value: [Token<TokenKind>, number]): number {
+    switch (value[0].text) {
+        case '+':
+            return +value[1];
+        case '-':
+            return -value[1];
+        default:
+            throw new Error(`Unknown unary operator: ${value[0].text}`);
+    }
+}
+
+function applyBinary(first: number, second: [Token<TokenKind>, number]): number {
+    switch (second[0].text) {
+        case '+':
+            return first + second[1];
+        case '-':
+            return first - second[1];
+        case '*':
+            return first * second[1];
+        case '/':
+            return first / second[1];
+        default:
+            throw new Error(`Unknown binary operator: ${second[0].text}`);
+    }
+}
+
+const parserModule = makeParserModule(
+    {
+        /*
+         * TERM
+         *  = NUMBER
+         *  = ('+' | '-') TERM
+         *  = '(' EXP ')'
+         */
+        TERM(m: { TERM: Parser<TokenKind, number>; EXP: Parser<TokenKind, number> }): Parser<TokenKind, number> {
+            return alt(
+                apply(tok(TokenKind.Number), applyNumber),
+                apply(seq(alt(str('+'), str('-')), m.TERM), applyUnary),
+                kmid(str('('), m.EXP, str(')'))
+            );
+        },
+        /*
+         * FACTOR
+         *  = TERM
+         *  = FACTOR ('*' | '/') TERM
+         */
+        FACTOR(m: { TERM: Parser<TokenKind, number> }): Parser<TokenKind, number> {
+            return lrec_sc(m.TERM, seq(alt(str('*'), str('/')), m.TERM), applyBinary);
+        },
+        /*
+         *EXP
+         *  = FACTOR
+         *  = EXP ('+' | '-') FACTOR
+         */
+        EXP(m: { FACTOR: Parser<TokenKind, number> }): Parser<TokenKind, number> {
+            return lrec_sc(m.FACTOR, seq(alt(str('+'), str('-')), m.FACTOR), applyBinary);
+        }
+    },
+    (m: { EXP: Parser<TokenKind, number> }): Parser<TokenKind, number> => m.EXP
+);
+
+function evaluate(expr: string): number {
+    return expectSingleResult(expectEOF(parserModule.parse(lexer.parse(expr))));
+}
+
+test(`Parser: calculator`, () => {
+    assert.strictEqual(evaluate('1'), 1);
+    assert.strictEqual(evaluate('+1.5'), 1.5);
+    assert.strictEqual(evaluate('-0.5'), -0.5);
+    assert.strictEqual(evaluate('1 + 2'), 3);
+    assert.strictEqual(evaluate('1 - 2'), -1);
+    assert.strictEqual(evaluate('1 * 2'), 2);
+    assert.strictEqual(evaluate('1 / 2'), 0.5);
+    assert.strictEqual(evaluate('1 + 2 * 3 + 4'), 11);
+    assert.strictEqual(evaluate('(1 + 2) * (3 + 4)'), 21);
+    assert.strictEqual(evaluate('1.2--3.4'), 4.6);
+});

--- a/packages/tspc-test/src/TestParserModule.ts
+++ b/packages/tspc-test/src/TestParserModule.ts
@@ -93,12 +93,11 @@ const parserModule = makeParserModule(
         EXP(m: { FACTOR: Parser<TokenKind, number> }): Parser<TokenKind, number> {
             return lrec_sc(m.FACTOR, seq(alt(str('+'), str('-')), m.FACTOR), applyBinary);
         }
-    },
-    (m: { EXP: Parser<TokenKind, number> }): Parser<TokenKind, number> => m.EXP
+    }
 );
 
 function evaluate(expr: string): number {
-    return expectSingleResult(expectEOF(parserModule.parse(lexer.parse(expr))));
+    return expectSingleResult(expectEOF(parserModule.EXP.parse(lexer.parse(expr))));
 }
 
 test(`Parser: calculator`, () => {


### PR DESCRIPTION
### Motivation
Using the `rule` parser alone does not enforce enough structure and level of abstraction when maintaining parsers  that contain more than a hand full of mutually dependent definitions. This PR tries to give consumers a tool to make combining and composing parsers at scale less of a headache. The concept introduced in this PR allows to structure mutually dependent parsers in a modular and coherent way while keeping the interface surface as small as possible. The concept is functionally equivalent to the `rules` parser concept:

(From https://github.com/mister-what/ts-parsec/blob/bcacd974a89b5edf8b5705fb070b7be829a68331/packages/tspc-test/src/TestParserModule.ts#L65-L101)
```ts
const parserModule = makeParserModule(
    {
        /*
         * TERM
         *  = NUMBER
         *  = ('+' | '-') TERM
         *  = '(' EXP ')'
         */
        TERM(m: { TERM: Parser<TokenKind, number>; EXP: Parser<TokenKind, number> }): Parser<TokenKind, number> {
            return alt(
                apply(tok(TokenKind.Number), applyNumber),
                apply(seq(alt(str('+'), str('-')), m.TERM), applyUnary),
                kmid(str('('), m.EXP, str(')'))
            );
        },
        /*
         * FACTOR
         *  = TERM
         *  = FACTOR ('*' | '/') TERM
         */
        FACTOR(m: { TERM: Parser<TokenKind, number> }): Parser<TokenKind, number> {
            return lrec_sc(m.TERM, seq(alt(str('*'), str('/')), m.TERM), applyBinary);
        },
        /*
         *EXP
         *  = FACTOR
         *  = EXP ('+' | '-') FACTOR
         */
        EXP(m: { FACTOR: Parser<TokenKind, number> }): Parser<TokenKind, number> {
            return lrec_sc(m.FACTOR, seq(alt(str('+'), str('-')), m.FACTOR), applyBinary);
        }
    }
);

function evaluate(expr: string): number {
    return expectSingleResult(expectEOF(parserModule.EXP.parse(lexer.parse(expr))));
}
```

### Changes

- adding factory to create mutually dependent parsers in a coherent and modular way.
- introduce LazyParser as an abstraction over the `rule` parser
- add test(based on `Parser: calculator` test) for parser modules
  - the test also covers the `lazyParser` implementation as it is the base building block for the parser module concept 